### PR TITLE
Add support for creating empty envs

### DIFF
--- a/gurobi-sys/src/lib.rs
+++ b/gurobi-sys/src/lib.rs
@@ -296,6 +296,8 @@ impl_from! { IntAttr CharAttr DoubleAttr StringAttr }
 extern "C" {
   pub fn GRBloadenv(envP: *mut *mut GRBenv, logfilename: c_str) -> c_int;
 
+  pub fn GRBemptyenv(envP: *mut *mut GRBenv) -> c_int;
+
   pub fn GRBloadclientenv(envP: *mut *mut GRBenv, logfilename: c_str, computeserver: c_str, port: c_int,
                           password: c_str, priority: c_int, timeout: c_double)
                           -> c_int;

--- a/src/env.rs
+++ b/src/env.rs
@@ -34,6 +34,19 @@ impl Env {
     })
   }
 
+  /// Create empty environment
+  pub fn empty() -> Result<Env> {
+    let mut env = null_mut();
+    let error = unsafe { ffi::GRBemptyenv(&mut env) };
+    if error != 0 {
+      return Err(Error::FromAPI(get_error_msg(env), error));
+    }
+    Ok(Env {
+      env: env,
+      require_drop: true
+    })
+  }
+
   /// Create a client environment on a computer server with log file
   pub fn new_client(logfilename: &str, computeserver: &str, port: i32, password: &str, priority: i32, timeout: f64)
                     -> Result<Env> {


### PR DESCRIPTION
Adding a support for creating empty env. This will allow you to call the set function before gurobi checks the license. This is essential for some licenses.